### PR TITLE
Colored ouptut: error when `tput` binary is not available.

### DIFF
--- a/src/shared/environment/UnixoidEnvironment.php
+++ b/src/shared/environment/UnixoidEnvironment.php
@@ -60,7 +60,12 @@ class UnixoidEnvironment extends Environment {
             return false;
         }
 
-        $tput          = $this->getPathToCommand('tput');
+        try {
+            $tput = $this->getPathToCommand('tput');
+        } catch (EnvironmentException $error) {
+            return false;
+        }
+        
         $commandResult = $this->executor->execute($tput, 'colors');
 
         if (!$commandResult->isSuccess()) {


### PR DESCRIPTION
`tput` is used to check if the colored output is available or not. The `getPathToCommand` throw an `EnvironmentException` when a command can't be found.

This exception make the execution fail if the `tput` binary can't be found on the running machine. We can just return false if `tput` can't be found to disable colored output.